### PR TITLE
Überarbeitung ´merge.sc()´

### DIFF
--- a/R/merge.sc.R
+++ b/R/merge.sc.R
@@ -22,53 +22,50 @@ merge.sc <- function(x, # Daten
                      col2.name = "n", # Name der n-Spalte in Tabelle
                      order.table = FALSE, # Soll nach Häufigkeit sortiert werden? "decreasing" für absteigendes Sortieren
                      show.plot = set.analysis.defaults$show.plot.sc, # Soll der Plot angezeigt werden?
-                     no.pagebreak = TRUE) # Seitenumbrüche mittendrin verhindern?
+                     pagebreak = FALSE) # Seitenumbruch dahinter?
 {
-  if (sum(!is.na(x)) > 0) {
-
-    if(already.labels == FALSE) {
-      #x <- sjlabelled::to_label(x) #bisherige Lösung, jetzt ohne sjlabelled
-      a <- attributes(x)
-      x <- factor(x, levels = a$labels, labels = names(a$labels))
-      attr(x, "label") <- a$label
-      }
-
-    if (inkl == "nr") {
-      if (nr == "") {inkl <- TRUE} else {inkl <- eval(parse(text = paste0("inkl.", nr)))}
-    }
-
-    if (inkl == TRUE) {
-      if(no.pagebreak == TRUE) #{cat("\\begin{minipage}{\\linewidth} \n")} # funktioniert nicht in Quarto
-      {cat("{{< pagebreak >}} \n  \n")}
-      cat("###", nr, attr(x, "label"), "\n \n")
-
-
-
-      #      print(table.freq(x, col1.name = "Antwortoption", col2.name = col2.name, # kein Print bei Flextable
-      #                       order.table = order.table))
-      subchunkify(table.freq(x, col1.name = "Antwortoption", col2.name = col2.name,
-                                  order.table = order.table))
-
-      freq.tab <- descr::freq(x, plot = FALSE)
-      results <- data.frame(rownames(freq.tab), round(freq.tab[, 1:2], digits = 2))
-      
-      # automatische Zeilenumbrüche bei langen Labels ---------------------
-      results[, 1] <- sapply(results[, 1], \(x) paste(strwrap(x, width = 40), collapse = "\n"))
-      
-      results <- results[!(rownames(results) %in% c("NA's", "Total")), ]
-      colnames(results) <- c("label", "freq", "perc")
-
-      if(show.plot == TRUE) {
-        if(fig.height == "default")
-        {subchunkify(barplot.sc.mc(results, xlab = "Häufigkeit"), fig_height = (1 + 0.75*nrow(results)), fig_width = 9)}
-        else
-        {subchunkify(barplot.sc.mc(x = results, xlab = "Häufigkeit"), fig_height = fig.height, fig_width = 9)}
-      }
-      if(no.pagebreak == TRUE) {
-        cat("\n\n\n")
-      }
-      cat("   \n  \n")
-
-    }
+  if (inkl == "nr") {
+    if (nr == "") {inkl <- TRUE} else {inkl <- eval(parse(text = paste0("inkl.", nr)))}
   }
+
+  if (inkl != TRUE) return(invisible()) # wenn inkl nicht TRUE, wird Funktion beendet
+  
+  if (sum(!is.na(x)) == 0) stop("Ausgewählte Spalte enthält keine Werte")
+
+  if(already.labels == FALSE) {
+    #x <- sjlabelled::to_label(x) #bisherige Lösung, jetzt ohne sjlabelled
+    a <- attributes(x)
+    x <- factor(x, levels = a$labels, labels = names(a$labels))
+    attr(x, "label") <- a$label
+  }
+
+  cat("###", nr, attr(x, "label"), "\n \n")
+
+  subchunkify(table.freq(x, col1.name = "Antwortoption", col2.name = col2.name,
+                         order.table = order.table))
+
+  freq.tab <- descr::freq(x, plot = FALSE)
+  results <- data.frame(rownames(freq.tab), round(freq.tab[, 1:2], digits = 2))
+    
+    # automatische Zeilenumbrüche bei langen Labels ---------------------
+  results[, 1] <- sapply(results[, 1], \(x) paste(strwrap(x, width = 40), collapse = "\n"))
+    
+  results <- results[!(rownames(results) %in% c("NA's", "Total")), ]
+  colnames(results) <- c("label", "freq", "perc")
+
+  if (show.plot == TRUE) {
+    if (fig.height == "default") {
+      subchunkify(barplot.sc.mc(results, xlab = "Häufigkeit"),
+                  fig_height = (1 + 0.75*nrow(results)), fig_width = 9)
+    } else {
+      subchunkify(barplot.sc.mc(x = results, xlab = "Häufigkeit"),
+                  fig_height = fig.height, fig_width = 9)}
+    }
+    
+  if (pagebreak == TRUE) {
+    cat("\n {{< pagebreak >}}")
+    }
+  
+  cat("\n \n")
+
 }

--- a/man/merge.sc.Rd
+++ b/man/merge.sc.Rd
@@ -13,7 +13,7 @@
   col2.name = "n",
   order.table = FALSE,
   show.plot = set.analysis.defaults$show.plot.sc,
-  no.pagebreak = TRUE
+  pagebreak = FALSE
 )
 }
 \arguments{


### PR DESCRIPTION
Seitenumbrüche finden jetzt erst nach den Inhalten statt (bisher davor) und auch erst, wenn man das pagebreak-Argument auf TRUE stellt. Außerdem habe ich die Verschachtelung der if-Statements deutlich reduziert.