### PR TITLE
kleine Änderung appendix.open

### DIFF
--- a/R/appendix.open.R
+++ b/R/appendix.open.R
@@ -12,7 +12,7 @@ appendix.open <- function() {
   
   anchor.nr <- list.open.answers$anchor.nr
   
-  if (anchor.nr == 0)  {return()} # stoppen, wenn keine offenen Fragen aufgerufen wurden
+  if (anchor.nr == 0)  {return(invisible())} # stoppen, wenn keine offenen Fragen aufgerufen wurden
   
   cat("# Anhang: Fragen mit offenem Antwortformat  \n  \n")
   


### PR DESCRIPTION
bisher wurde fälschlicherweise NULL erzeugt wenn bei ´appendix.open()´ keine offenen Antworten existierten